### PR TITLE
Move Touch Ups

### DIFF
--- a/packs/moves/amethyst-mandala.json
+++ b/packs/moves/amethyst-mandala.json
@@ -22,11 +22,13 @@
         "img": "systems/ptr2e/img/svg/fairy_icon.svg",
         "traits": [
           "digimon",
-          "friendly"
+          "friendly",
+          "flinch-50",
+          "arcane"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 8
         },
         "types": [
           "psychic",
@@ -34,20 +36,77 @@
         ],
         "category": "special",
         "predicate": [],
-        "description": "<p>This attack is both @Trait[fairy] and @Trait[psychic]. On hit, this attack removes all positive @Trait[stage-change] effects from affected targets.</p>",
+        "description": "<p>Effect: On hit, this attack removes all positive @Trait[stage-change] effects from affected targets. This attack is both @Trait[fairy] and @Trait[psychic], and is one step more effective against the @Trait[ghost] Type.</p></p>",
         "range": {
           "target": "emanation",
-          "distance": 5,
+          "distance": 6,
           "unit": "m"
         },
         "power": 100,
-        "accuracy": 100
+        "accuracy": 95
       }
     ],
     "grade": "S",
     "slug": "amethyst-mandala"
   },
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Amethyst Mandala",
+      "type": "passive",
+      "_id": "KCA0ukkrOJBDZsoj",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "amethyst-mandala-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [
+              "target:trait:ghost"
+            ],
+            "label": "Vs Ghost",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771261243539,
+        "modifiedTime": 1771261273207,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "ezREwZ8X0FHOdGFJ"
 }

--- a/packs/moves/arctic-blizzard.json
+++ b/packs/moves/arctic-blizzard.json
@@ -21,9 +21,9 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/ice_icon.svg",
         "traits": [
-          "contact",
-          "crushing",
-          "digimon"
+          "digimon",
+          "wind",
+          "friendly"
         ],
         "cost": {
           "activation": "complex",
@@ -32,15 +32,14 @@
         "types": [
           "ice"
         ],
-        "category": "physical",
+        "category": "status",
         "predicate": [],
-        "description": "<p>This attack has a 40% chance to inflict @Affliction[frozen 1].</p>",
+        "description": "<p>>Effect: On hit, all valid targets have a 20% chance of gaining @Affliction[frozen 2], and have a 70% chance of gaining @Affliction[frozen 1].</p>",
         "range": {
-          "target": "creature",
-          "distance": 1,
+          "target": "emanation",
+          "distance": 6,
           "unit": "m"
         },
-        "power": 125,
         "accuracy": 100
       }
     ],
@@ -61,11 +60,30 @@
             "key": "arctic-blizzard-attack",
             "value": "Compendium.ptr2e.core-effects.Item.frozencondititem",
             "predicate": [],
-            "chance": 40,
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "dontMerge": true,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "arctic-blizzard-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frozencondititem",
+            "predicate": [],
+            "chance": 70,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [],
-            "dontMerge": false,
+            "dontMerge": true,
             "mode": 2,
             "ignored": false
           }

--- a/packs/moves/atomic-ray.json
+++ b/packs/moves/atomic-ray.json
@@ -26,27 +26,105 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 8
         },
         "types": [
           "nuclear"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack has a 40% chance to inflict @Affliction[delay 50] and a 60% chance to inflict @Affliction[quantum-entanglement].</p>",
+        "description": "<p>Effect: On hit, the target has a  20% chance of being @Affliction[delay 50] and a 30% chance of gaining @Affliction[desync 1].</p>",
         "range": {
           "target": "creature",
           "distance": 15,
           "unit": "m"
         },
         "power": 125,
-        "accuracy": 100
+        "accuracy": 100,
+        "defensiveStat": "spd"
       }
     ],
     "grade": "S"
   },
   "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Atomic Ray",
+      "type": "passive",
+      "_id": "pRCd3LrWzRhpiBtW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "atomic-ray-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -50
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "atomic-ray-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.desynccondititem",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771262568415,
+        "modifiedTime": 1771262649375,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "flags": {},
   "_id": "KRdqmPfOcJAF8uhx"
 }

--- a/packs/moves/baby-breath.json
+++ b/packs/moves/baby-breath.json
@@ -21,12 +21,12 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/dragon_icon.svg",
         "traits": [
-          "missile",
+          "pulse",
           "digimon"
         ],
         "range": {
           "target": "creature",
-          "distance": 5,
+          "distance": 4,
           "unit": "m"
         },
         "cost": {
@@ -37,9 +37,10 @@
           "dragon"
         ],
         "category": "physical",
-        "power": 75,
+        "power": 65,
         "accuracy": 100,
-        "predicate": []
+        "predicate": [],
+        "defensiveStat": "spd"
       }
     ],
     "grade": "D",

--- a/packs/moves/banana-slip.json
+++ b/packs/moves/banana-slip.json
@@ -21,25 +21,26 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/normal_icon.svg",
         "traits": [
-          "digimon"
+          "digimon",
+          "priority-30"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 9
+          "powerPoints": 6
         },
         "types": [
           "normal"
         ],
         "category": "special",
         "predicate": [],
-        "description": "<p>This attack has an 80% chance to inflict @Affliction[frozen 1].</p>",
+        "description": "<p>Effect: On hit, the target loses -2 SPD Stages for 5 Activations, and has a 30% of gaining @Affliction[delay 60].</p>",
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 3,
           "unit": "m"
         },
-        "power": 115,
-        "accuracy": 100
+        "power": 40,
+        "accuracy": 90
       }
     ],
     "grade": "S"
@@ -56,9 +57,28 @@
           {
             "type": "roll-effect",
             "key": "banana-slip-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.frozencondititem",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
             "predicate": [],
-            "chance": 80,
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -60
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "banana-slip-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.9FlxAAlUW2PrKOd0",
+            "predicate": [],
+            "chance": 100,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [],

--- a/packs/moves/bantyo-blade.json
+++ b/packs/moves/bantyo-blade.json
@@ -28,27 +28,82 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 11
+          "powerPoints": 7
         },
         "types": [
           "normal"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>Before rolling this attack, the user must roll a d3. Modify the attack's effectiveness stage using an ad-hoc modifier based on the following results.<br><br>1 - Apply -1 Effectiveness Stage<br>2 - Do not modify the Effectiveness Stage<br>3 - Apply +1 Effectiveness Stage.</p>",
+        "description": "<p>Effect: This attack's Power ranges based on how damaged the user is, ranging from 30 to 300.</p>",
         "range": {
           "target": "creature",
           "distance": 1,
           "unit": "m"
         },
-        "power": 150,
+        "power": 30,
         "accuracy": 100
       }
     ],
     "grade": "S"
   },
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Bantyo Blade",
+      "type": "passive",
+      "_id": "0IO8OhmtnSKu4b87",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "bantyo-blade-attack-power",
+            "value": "min(270, 3 * (100-@actor.system.health.percent))",
+            "predicate": [],
+            "label": "Bantyo Blade",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771263199194,
+        "modifiedTime": 1771287666046,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "flags": {},
   "_id": "2C5JxLlzHRH4TTG6"
 }

--- a/packs/moves/bifrost.json
+++ b/packs/moves/bifrost.json
@@ -22,25 +22,28 @@
         "img": "systems/ptr2e/img/svg/fairy_icon.svg",
         "traits": [
           "digimon",
-          "missile"
+          "missile",
+          "priority-20"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 9
         },
         "types": [
-          "fairy"
+          "fairy",
+          "fire"
         ],
-        "category": "special",
+        "category": "physical",
         "predicate": [],
-        "description": "<p>On resolution, this attack grants the user @UUID[Compendium.ptr2e.core-effects.XeiSuS3APUcN0MLM]{+1 Speed Stage for 5 activations}.</p>",
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[burn 7]. On resolution, the user has a 25% chance of gaining +1 SPD Stage for 7 Activations.</p>",
         "range": {
           "target": "creature",
           "distance": 15,
           "unit": "m"
         },
         "power": 120,
-        "accuracy": 100
+        "accuracy": 100,
+        "defensiveStat": "spd"
       }
     ],
     "grade": "S",
@@ -58,12 +61,37 @@
           {
             "type": "roll-effect",
             "key": "bifrost-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 50,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bifrost-attack",
             "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
             "predicate": [],
-            "chance": 100,
+            "chance": 25,
             "isFixedChance": false,
             "affects": "self",
-            "alterations": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
             "dontMerge": false,
             "mode": 2,
             "ignored": false

--- a/packs/moves/big-bang-voice.json
+++ b/packs/moves/big-bang-voice.json
@@ -34,14 +34,14 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack has a 20% chance to inflict @Affliction[paralysis 5].</p>",
+        "description": "<p><p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[paralysis 5].</p>",
         "range": {
-          "target": "emanation",
-          "distance": 4,
+          "target": "wide-line",
+          "distance": 7,
           "unit": "m"
         },
         "power": 120,
-        "accuracy": 100
+        "accuracy": 90
       }
     ],
     "grade": "A",
@@ -61,7 +61,7 @@
             "key": "big-bang-voice-attack",
             "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
             "predicate": [],
-            "chance": 20,
+            "chance": 30,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [],

--- a/packs/moves/biting-crush.json
+++ b/packs/moves/biting-crush.json
@@ -24,7 +24,10 @@
           "digimon",
           "contact",
           "grapple",
-          "jaw"
+          "jaw",
+          "crit-2",
+          "crash-1-2",
+          "flinch-20"
         ],
         "cost": {
           "activation": "complex",
@@ -35,14 +38,14 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>Effect: This attack has a 15% Fixed Chance to inflict @Affliction[perish 1].</p>",
+        "description": "<p>Effect: On hit, the target has a 20% chance of losing -1 DEF and SPDEF Stage for 7 Activations. This Attack gains +20 Accuracy while the user is @Affliction[grapple].</p>",
         "range": {
           "target": "creature",
           "distance": 1,
           "unit": "m"
         },
-        "power": 145,
-        "accuracy": 100
+        "power": 215,
+        "accuracy": 80
       }
     ],
     "grade": "S"
@@ -57,18 +60,49 @@
       "system": {
         "changes": [
           {
+            "type": "flat-modifier",
+            "key": "biting-crush-attack-accuracy",
+            "value": 20,
+            "predicate": [
+              "effect:affliction:grapple"
+            ],
+            "label": "Biting Crush (Grapple)",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
             "type": "roll-effect",
             "key": "biting-crush-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.perishcondititem",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
             "predicate": [],
-            "chance": 15,
+            "chance": 20,
             "isFixedChance": true,
             "affects": "target",
             "alterations": [
               {
                 "mode": 5,
                 "property": "duration.turns",
-                "value": 1
+                "value": 7
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "biting-crush-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
               }
             ],
             "dontMerge": false,

--- a/packs/moves/black-aura-blast.json
+++ b/packs/moves/black-aura-blast.json
@@ -21,24 +21,28 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "traits": [
-          "digimon"
+          "digimon",
+          "pulse",
+          "aura",
+          "priority-20"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 9
         },
         "types": [
-          "psychic"
+          "psychic",
+          "dark"
         ],
         "category": "special",
         "predicate": [],
-        "description": "<p>On hit, this attack inflicts @UUID[Compendium.ptr2e.core-effects.B79G2s6TauIlmsno]{-2 Defense Stages for 5 activations} to the target.</p>",
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[confused 7]. This attack is more powerful the slower the user is compared to the target ranging from 80 to 180.</p>",
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 9,
           "unit": "m"
         },
-        "power": 110,
+        "power": 80,
         "accuracy": 100
       }
     ],
@@ -54,14 +58,30 @@
       "system": {
         "changes": [
           {
+            "type": "flat-modifier",
+            "key": "black-aura-blast-attack-power",
+            "value": "-round(min(100,max(0,3*((@actor.system.attributes.spe.final*3.5-@target.system.attributes.spe.final)/@actor.system.attributes.spe.final))))",
+            "predicate": [],
+            "label": "Black Aura Blast Scaling",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
             "type": "roll-effect",
             "key": "black-aura-blast-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.B79G2s6TauIlmsno",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
             "predicate": [],
-            "chance": 100,
+            "chance": 50,
             "isFixedChance": false,
             "affects": "target",
-            "alterations": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
             "dontMerge": false,
             "mode": 2,
             "ignored": false

--- a/packs/moves/black-rain.json
+++ b/packs/moves/black-rain.json
@@ -16,29 +16,90 @@
     "traits": [],
     "actions": [
       {
-        "name": "Black Rain",
-        "slug": "black-rain",
+        "name": "Black Rain (Set-Up)",
+        "slug": "black-rain-set-up",
         "type": "attack",
         "img": "systems/ptr2e/img/svg/dark_icon.svg",
         "traits": [
-          "digimon"
+          "digimon",
+          "priority-20",
+          "set-up",
+          "environ"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 15
+          "powerPoints": 8,
+          "trigger": "",
+          "delay": null,
+          "priority": null
+        },
+        "types": [
+          "dark"
+        ],
+        "category": "status",
+        "predicate": [],
+        "description": "<p>Effect: The user gains @Affliction[braced 2]. If Gloomy or Shady Weather is present, the user may use Black Rain (Resolution) as a Free Action upon resolving this Attack.</p>",
+        "range": {
+          "target": "self",
+          "unit": "m",
+          "distance": 0
+        },
+        "power": null,
+        "accuracy": null,
+        "variant": null,
+        "ephemeralVariant": false,
+        "summon": null,
+        "contestType": "",
+        "contestEffect": "",
+        "free": false,
+        "slot": null,
+        "defaultVariant": null,
+        "flingItemId": "",
+        "offensiveStat": null,
+        "defensiveStat": null
+      },
+      {
+        "name": "Black Rain (Resolution)",
+        "slug": "black-rain-resolution",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/dark_icon.svg",
+        "traits": [
+          "digimon",
+          "ray",
+          "crit-1",
+          "flinch-60"
+        ],
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 8,
+          "trigger": "",
+          "delay": null,
+          "priority": null
         },
         "types": [
           "dark"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack launches an artillery bombardment into the sky that descends like rain. This attack targets friend and foe alike indiscriminately, but cannot affect the user.<br><br>Targets cannot claim Cover against this attack. This attack has a 20% chance to apply @Affliction[confused 5].</p>",
+        "description": "<p>Trigger: The user used Black Rain (Set-Up) as their last Action.</p><p>Effect: This Attack targets foes' SPD, rather than DEF. On hit, all valid targets have a 40% chance of gaining @Affliction[confused 5] and a 20% chance of gaining @Affliction[wracked 5].</p>",
         "range": {
           "target": "field",
-          "unit": "m"
+          "unit": "m",
+          "distance": null
         },
-        "power": 150,
-        "accuracy": 100
+        "power": 200,
+        "accuracy": 90,
+        "variant": "black-rain-set-up",
+        "ephemeralVariant": false,
+        "summon": null,
+        "contestType": "",
+        "contestEffect": "",
+        "free": false,
+        "slot": null,
+        "defaultVariant": null,
+        "flingItemId": "",
+        "offensiveStat": null,
+        "defensiveStat": "spe"
       }
     ],
     "grade": "S"
@@ -54,11 +115,37 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "black-rain-attack",
+            "key": "black-rain-resolution-attack",
             "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 40,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "black-rain-resolution-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wrackedcondiitem",
             "predicate": [],
             "chance": 20,
             "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "black-rain-set-up-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bracedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
             "affects": "target",
             "alterations": [],
             "dontMerge": false,

--- a/packs/moves/blade-of-the-dragon-king.json
+++ b/packs/moves/blade-of-the-dragon-king.json
@@ -41,13 +41,83 @@
           "unit": "m"
         },
         "power": 150,
-        "accuracy": 100
+        "accuracy": 100,
+        "description": "<p>Effect: This Attack is one-step more effective against and deals +30% more damage to @Trait[royal-knight] creatures.</p>"
       }
     ],
     "grade": "S",
     "slug": "blade-of-the-dragon-king"
   },
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Blade of the Dragon King",
+      "type": "passive",
+      "_id": "3qfzKD9q2Gu6P8D5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "blade-of-the-dragon-king-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [
+              "target:trait:royal-knight"
+            ],
+            "label": "Vs Royal Knight",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "blade-of-the-dragon-king-attack-damage",
+            "value": 30,
+            "predicate": [
+              "target:trait:royal-knight"
+            ],
+            "label": "Vs Royal Knight",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771265078112,
+        "modifiedTime": 1771287897869,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "tBWpFO33y2Zca2zk"
 }

--- a/packs/moves/blaze-sonic-breath.json
+++ b/packs/moves/blaze-sonic-breath.json
@@ -22,25 +22,26 @@
         "img": "systems/ptr2e/img/svg/fire_icon.svg",
         "traits": [
           "sonic",
-          "digimon"
+          "digimon",
+          "pulse"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 5
         },
         "types": [
           "fire"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>Effect: On Resolution the user gains @UUID[Compendium.ptr2e.core-effects.XeiSuS3APUcN0MLM]{+1 Speed Stage for 5 activations}</p>",
+        "description": "<p>Effect: On resolution, the user has a 50% chance of gaining +1 SPD Stage for 5 Activations.</p>",
         "range": {
           "target": "line",
-          "distance": 9,
+          "distance": 7,
           "unit": "m"
         },
         "power": 100,
-        "accuracy": 100
+        "accuracy": 90
       }
     ],
     "grade": "A",
@@ -60,7 +61,7 @@
             "key": "blaze-sonic-breath-attack",
             "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
             "predicate": [],
-            "chance": 100,
+            "chance": 50,
             "affects": "self",
             "alterations": [],
             "dontMerge": false,

--- a/packs/moves/blue-flare-breath.json
+++ b/packs/moves/blue-flare-breath.json
@@ -34,7 +34,7 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack inflicts -1 Defense Stage for 5 Activations.</p>",
+        "description": "<p>Effect: On hit, the target has a 40% chance to lose -1 DEF Stage for 5 Activations. This Attack is one step more effective against the @Trait[fairy] Type.</p>",
         "range": {
           "target": "creature",
           "distance": 5,
@@ -57,17 +57,29 @@
       "system": {
         "changes": [
           {
+            "type": "flat-modifier",
+            "key": "blue-flare-breath-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [
+              "target:trait:fairy"
+            ],
+            "label": "Vs Fairy",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
             "type": "roll-effect",
             "key": "blue-flare-breath-attack",
             "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
             "predicate": [],
-            "chance": 100,
+            "chance": 40,
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
+            "isFixedChance": false,
             "mode": 2,
-            "ignored": false,
-            "isFixedChance": false
+            "ignored": false
           }
         ],
         "slug": null,

--- a/packs/moves/brave-metal.json
+++ b/packs/moves/brave-metal.json
@@ -16,44 +16,15 @@
     "traits": [],
     "actions": [
       {
-        "name": "Brave Metal",
-        "slug": "brave-metal-resolution",
-        "type": "attack",
-        "img": "systems/ptr2e/img/svg/steel_icon.svg",
-        "traits": [
-          "digimon",
-          "set-up",
-          "contact",
-          "dash",
-          "flinch-60",
-          "partial-automation"
-        ],
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "types": [
-          "steel"
-        ],
-        "category": "physical",
-        "predicate": [],
-        "description": "<p>Resolution: The user moves up to 1.5x their preferred Movement Allowance and resolved Brave Metal.</p>",
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "power": 200,
-        "accuracy": 100
-      },
-      {
         "name": "Brave Metal (Set-Up)",
-        "slug": "brave-metal-setup",
-        "description": "<p>Effect: The User converts @Tick[-2] into @Tick[2 shield], gains [Contempt] and @UUID[Compendium.ptr2e.core-effects.ZGwaMlzUwkSuCPyH]{+1 Attack Stage} for 5 activations.</p>",
+        "slug": "brave-metal-set-up",
+        "description": "<p>Effect: The user gains +2 ATK Stages for 3 Activations.</p>",
         "traits": [
-          "priority-30"
+          "priority-30",
+          "set-up",
+          "digimon"
         ],
-        "type": "generic",
+        "type": "attack",
         "img": "systems/ptr2e/img/svg/steel_icon.svg",
         "cost": {
           "activation": "complex",
@@ -62,7 +33,46 @@
         "range": {
           "target": "self",
           "unit": "m"
-        }
+        },
+        "types": [
+          "steel"
+        ],
+        "category": "status",
+        "predicate": []
+      },
+      {
+        "name": "Brave Metal (Resolution)",
+        "slug": "brave-metal-resolution",
+        "description": "<p>Trigger: The user used Brave Metal (Set-Up) as their last Action.</p><p>Effect: The user may freely Move Up to 1.5x the Movement Score of their choice as they resolve this Attack. This Attack is one step more effective against @Trait[dragon] and @Trait[fire] creatures.</p>",
+        "traits": [
+          "flinch-60",
+          "set-up",
+          "digimon",
+          "contact",
+          "dash",
+          "pass-4",
+          "crushing"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/steel_icon.svg",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6,
+          "trigger": "The user used Brave Metal (Set-Up) as their last Action."
+        },
+        "range": {
+          "target": "creature",
+          "unit": "m",
+          "distance": 1
+        },
+        "variant": "brave-metal-set-up",
+        "types": [
+          "steel"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 200,
+        "accuracy": 90
       }
     ],
     "grade": "S"
@@ -78,8 +88,8 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "brave-metal-setup-generic",
-            "value": "Compendium.ptr2e.core-effects.Item.4DlXFTVooz07YcDm",
+            "key": "brave-metal-set-up-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.g1Gt9mJWimAqrqZ0",
             "predicate": [],
             "chance": 100,
             "isFixedChance": true,
@@ -87,8 +97,8 @@
             "alterations": [
               {
                 "mode": 5,
-                "property": "system.changes.0.value",
-                "value": -2
+                "property": "duration.turns",
+                "value": 3
               }
             ],
             "dontMerge": false,
@@ -96,36 +106,28 @@
             "ignored": false
           },
           {
-            "type": "roll-effect",
-            "key": "brave-metal-setup-generic",
-            "value": "Compendium.ptr2e.core-effects.Item.k1FukpHKnZGqjSNc",
-            "predicate": [],
-            "chance": 100,
-            "isFixedChance": true,
-            "affects": "self",
-            "alterations": [
-              {
-                "mode": 5,
-                "property": "system.changes.0.value",
-                "value": 2
-              }
+            "type": "flat-modifier",
+            "key": "brave-metal-resolution-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [
+              "target:trait:dragon"
             ],
-            "dontMerge": false,
+            "label": "Vs Dragon",
             "mode": 2,
-            "ignored": false
+            "ignored": false,
+            "hideIfDisabled": false
           },
           {
-            "type": "roll-effect",
-            "key": "brave-metal-setup-generic",
-            "value": "Compendium.ptr2e.core-effects.Item.ZGwaMlzUwkSuCPyH",
-            "predicate": [],
-            "chance": 100,
-            "isFixedChance": false,
-            "affects": "self",
-            "alterations": [],
-            "dontMerge": false,
+            "type": "flat-modifier",
+            "key": "brave-metal-resolution-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [
+              "target:trait:fire"
+            ],
+            "label": "Vs Fire",
             "mode": 2,
-            "ignored": false
+            "ignored": false,
+            "hideIfDisabled": false
           }
         ],
         "slug": null,

--- a/packs/moves/brinded.json
+++ b/packs/moves/brinded.json
@@ -23,7 +23,8 @@
         "traits": [
           "digimon",
           "ray",
-          "crit-1"
+          "crit-1",
+          "flinch-30"
         ],
         "cost": {
           "activation": "complex",
@@ -39,8 +40,8 @@
           "distance": 10,
           "unit": "m"
         },
-        "power": 115,
-        "accuracy": 100
+        "power": 200,
+        "accuracy": 90
       }
     ],
     "grade": "A"

--- a/packs/moves/bunny-blades.json
+++ b/packs/moves/bunny-blades.json
@@ -24,12 +24,12 @@
           "contact",
           "crit-1",
           "double-strike",
-          "dash",
+          "hammer",
           "digimon"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 4
         },
         "types": [
           "flying"
@@ -37,12 +37,12 @@
         "category": "physical",
         "predicate": [],
         "range": {
-          "target": "enemy",
+          "target": "creature",
           "distance": 1,
           "unit": "m"
         },
-        "power": 55,
-        "accuracy": 100
+        "power": 65,
+        "accuracy": 90
       }
     ],
     "grade": "B",

--- a/packs/moves/burst-shot.json
+++ b/packs/moves/burst-shot.json
@@ -22,7 +22,7 @@
         "img": "systems/ptr2e/img/svg/steel_icon.svg",
         "traits": [
           "digimon",
-          "double-strike",
+          "3-strike",
           "missile"
         ],
         "cost": {
@@ -36,11 +36,11 @@
         "predicate": [],
         "range": {
           "target": "cone",
-          "distance": 4,
+          "distance": 6,
           "unit": "m"
         },
-        "power": 90,
-        "accuracy": 100
+        "power": 65,
+        "accuracy": 90
       }
     ],
     "grade": "S",

--- a/packs/moves/catastrophe-cannon.json
+++ b/packs/moves/catastrophe-cannon.json
@@ -24,24 +24,25 @@
           "3-strike",
           "digimon",
           "missile",
-          "flinch-30"
+          "explode",
+          "flinch-60"
         ],
         "cost": {
-          "activation": "simple"
+          "activation": "complex"
         },
         "types": [
           "fire"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>On resolution, after all attack rolls have been made, the user gains @Affliction[bound 2]. This is not automated.</p>",
+        "description": "<p>Effect: This attack's Power ranges based on how healthy the user is, ranging from 35 to 115.</p>",
         "range": {
           "target": "creature",
-          "distance": 12,
+          "distance": 16,
           "unit": "m"
         },
-        "power": 80,
-        "accuracy": 100
+        "power": 115,
+        "accuracy": 95
       }
     ],
     "grade": "S"

--- a/packs/moves/celestial-blade.json
+++ b/packs/moves/celestial-blade.json
@@ -23,14 +23,17 @@
         "traits": [
           "digimon",
           "sharp",
-          "missile"
+          "ray",
+          "missile",
+          "flinch-20"
         ],
         "cost": {
           "activation": "complex",
           "powerPoints": 9
         },
         "types": [
-          "electric"
+          "electric",
+          "fairy"
         ],
         "category": "special",
         "predicate": [],
@@ -39,8 +42,8 @@
           "distance": 7,
           "unit": "m"
         },
-        "power": 120,
-        "accuracy": 100
+        "power": 125,
+        "accuracy": 90
       }
     ],
     "grade": "S"

--- a/packs/moves/chrono-breaker.json
+++ b/packs/moves/chrono-breaker.json
@@ -21,30 +21,119 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "traits": [
-          "digimon"
+          "digimon",
+          "flat",
+          "flinch-20"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 6
         },
         "types": [
           "psychic"
         ],
         "category": "special",
         "predicate": [],
-        "description": "<p>This attack deals a fixed 50 flat damage, bypassing Special Defense.</p>",
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[delay 50] and a 20% chance of gaining @Affliction[drowsy 5]. This attack deals flat damage based on the user's level.</p><blockquote><p>Damage Formula: Damage = 2 x UserLevel</p></blockquote></p>",
         "range": {
-          "target": "enemy",
+          "target": "creature",
           "distance": 6,
           "unit": "m"
         },
         "accuracy": 100
       }
     ],
-    "grade": "C",
+    "grade": "A",
     "slug": "chrono-breaker"
   },
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Chrono Breaker",
+      "type": "passive",
+      "_id": "kmmuhQFGBbnOBune",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "chrono-breaker-attack-damage-flat",
+            "value": "floor(@actor.system.advancement.level * 2)",
+            "predicate": [],
+            "label": "Chrono Breaker",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "chrono-breaker-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 50,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -50
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "chrono-breaker-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771268835398,
+        "modifiedTime": 1771268952092,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "eCVDx08dhdJ7nNI2"
 }

--- a/packs/moves/cold-flame-digimon.json
+++ b/packs/moves/cold-flame-digimon.json
@@ -21,11 +21,12 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/ice_icon.svg",
         "traits": [
-          "digimon"
+          "digimon",
+          "pulse"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 6
         },
         "types": [
           "fire",
@@ -33,10 +34,10 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>On resolution, the user gains @UUID[Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa]{+1 Special Attack Stage for 5 activations} and <em>@UUID[Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3]{+1 Special Defense Stage for 5 activations}. This attack counts as both Fire and Ice Type.</em></p>",
+        "description": "<p>Effect: On resolution, the user gains +1 SPATK Stage for 5 Activations. This Attack is one more effective against the @Trait[ice] Type, and two steps more effective against the @Trait[fire] Type.</p>",
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
         "power": 100,
@@ -69,17 +70,28 @@
             "ignored": false
           },
           {
-            "type": "roll-effect",
-            "key": "cold-flame-digimon-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3",
-            "predicate": [],
-            "chance": 100,
-            "isFixedChance": false,
-            "affects": "self",
-            "alterations": [],
-            "dontMerge": false,
+            "type": "flat-modifier",
+            "key": "cold-flame-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [
+              "target:trait:ice"
+            ],
+            "label": "Vs Ice",
             "mode": 2,
-            "ignored": false
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "cold-flame-attack-effectiveness-stage",
+            "value": 2,
+            "predicate": [
+              "target:trait:fire"
+            ],
+            "label": "Vs Fire",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
           }
         ],
         "slug": null,

--- a/packs/moves/corona-blaster.json
+++ b/packs/moves/corona-blaster.json
@@ -22,7 +22,7 @@
         "img": "systems/ptr2e/img/svg/fire_icon.svg",
         "traits": [
           "ray",
-          "5-strike",
+          "6-strike",
           "digimon"
         ],
         "cost": {
@@ -36,12 +36,12 @@
         "predicate": [],
         "description": "<p>This attack has a 15% chance to apply @UUID[Compendium.ptr2e.core-effects.wA5oCsgHmZLcHHSn]{-1 Accuracy Stage for 5 activations}</p>",
         "range": {
-          "target": "enemy",
+          "target": "creature",
           "distance": 12,
           "unit": "m"
         },
-        "power": 30,
-        "accuracy": 100
+        "power": 35,
+        "accuracy": 95
       }
     ],
     "grade": "B",

--- a/packs/moves/cross-blade.json
+++ b/packs/moves/cross-blade.json
@@ -22,8 +22,7 @@
         "img": "systems/ptr2e/img/svg/fairy_icon.svg",
         "traits": [
           "contact",
-          "danger-close",
-          "crit-1",
+          "crit-2",
           "digimon"
         ],
         "cost": {
@@ -31,7 +30,8 @@
           "powerPoints": 6
         },
         "types": [
-          "fairy"
+          "fairy",
+          "steel"
         ],
         "category": "physical",
         "predicate": [],

--- a/packs/moves/dark-roar.json
+++ b/packs/moves/dark-roar.json
@@ -23,7 +23,7 @@
         "traits": [
           "digimon",
           "missile",
-          "crit-1"
+          "crit-2"
         ],
         "cost": {
           "activation": "complex",
@@ -35,7 +35,7 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack is considered both @Trait[nuclear] & @Trait[dark].</p>",
+        "description": "<p>Effect: On hit, the target has a 30% chance of being @Affliction[grounded 5].</p>",
         "range": {
           "target": "creature",
           "distance": 10,
@@ -49,6 +49,64 @@
     "slug": "dark-roar"
   },
   "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Dark Roar",
+      "type": "passive",
+      "_id": "LuFbsTPJeF4QQlUt",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "dark-roar-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.groundedconditem",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771269770331,
+        "modifiedTime": 1771269796253,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "3ddQH7d5Iok3KuIG"
 }

--- a/packs/moves/darkness-wave.json
+++ b/packs/moves/darkness-wave.json
@@ -22,11 +22,12 @@
         "img": "systems/ptr2e/img/svg/dark_icon.svg",
         "traits": [
           "summon",
-          "digimon"
+          "digimon",
+          "flinch-90"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 16
         },
         "types": [
           "dark"
@@ -34,7 +35,7 @@
         "category": "status",
         "summon": "Compendium.ptr2e-digimon-expansion.digimon-summons.Item.2wvQk3Wh46wP7cSe",
         "predicate": [],
-        "description": "<p>Effect: Summons a @UUID[Compendium.ptr2e-digimon-expansion.digimon-summons.2wvQk3Wh46wP7cSe]{Darkness Wave (Summon)} with a base AV of 60 and a duration of 5 activations. On each of the Summon's Activations, all enemy creatures are targeted by @UUID[Compendium.ptr2e-digimon-expansion.digimon-summons.Item.2wvQk3Wh46wP7cSe.Actions.darkness-wave-summon-action]{Darkness Wave (Summon) Action} . Only one Darkness Wave Summon may be active at any given time, with subsequent uses failing to activate.</p>",
+        "description": "<p>Effect: The user creates a Darkness Zone Summon@UUID[Compendium.ptr2e-digimon-expansion.digimon-summons.akIZVqFP7eWahuAT]{Darkness Zone (Summon)}. This Summon only expires if when the user gains @Affliction[fainted]. While this Summon is Active, creatures lose @Tick[-4] at the end of each of their Activations.</p>",
         "range": {
           "target": "field",
           "unit": "m"

--- a/packs/moves/data-crusher.json
+++ b/packs/moves/data-crusher.json
@@ -25,7 +25,7 @@
           "digimon"
         ],
         "range": {
-          "target": "enemy",
+          "target": "creature",
           "distance": 3,
           "unit": "m"
         },
@@ -58,18 +58,103 @@
           {
             "type": "roll-effect",
             "key": "data-crusher-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.perishcondititem",
+            "value": "Compendium.ptr2e.core-effects.Item.wA5oCsgHmZLcHHSn",
             "predicate": [],
-            "chance": 5,
-            "isFixedChance": true,
+            "chance": 10,
+            "isFixedChance": false,
             "affects": "target",
-            "alterations": [
-              {
-                "mode": 5,
-                "property": "duration.turns",
-                "value": 1
-              }
-            ],
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "data-crusher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "data-crusher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.64WFzbAdyfOZBrlv",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "data-crusher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "data-crusher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.hIE6W3Y5E9CyHiTy",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "data-crusher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "data-crusher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "data-crusher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
             "dontMerge": false,
             "mode": 2,
             "ignored": false
@@ -94,17 +179,21 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {},
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1754299948146,
-        "modifiedTime": 1754299989858,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+        "modifiedTime": 1771277671419,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
       }
     }
   ],

--- a/packs/moves/dead-or-alive.json
+++ b/packs/moves/dead-or-alive.json
@@ -21,24 +21,25 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "traits": [
-          "digimon"
+          "digimon",
+          "crit-1"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 9
+          "powerPoints": 8
         },
         "types": [
           "untyped"
         ],
         "category": "special",
         "predicate": [],
-        "description": "<p>This attack has a 30% chance to apply @Affliction[stunted 5], and a 5% fixed chance to apply @Affliction[perish 1].</p>",
+        "description": "<p>Effect: This Attack is unaffected by the effects of a target's @Trait[defensive] Abilities. On hit, the target has a 30% chance of being afflicted with @Affliction[wracked 5]. On a Critical Hit, this Attack deals flat damage equal to 3.5x the user's level, and the target gains @Affliction[perish 3].</p>",
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 11,
           "unit": "m"
         },
-        "power": 130,
+        "power": 90,
         "accuracy": 100
       }
     ],
@@ -69,7 +70,7 @@
           },
           {
             "type": "roll-effect",
-            "key": "dead-or-alive-attack",
+            "key": "dead-or-alive-attack-crit",
             "value": "Compendium.ptr2e.core-effects.Item.perishcondititem",
             "predicate": [],
             "chance": 5,
@@ -79,7 +80,31 @@
               {
                 "mode": 5,
                 "property": "duration.turns",
-                "value": 1
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "dead-or-alive-attack-crit",
+            "value": "Compendium.ptr2e.core-effects.Item.4DlXFTVooz07YcDm",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.isFlat",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": "floor(@actor.system.advancement.level * 3.5)"
               }
             ],
             "dontMerge": false,

--- a/packs/moves/death-claw.json
+++ b/packs/moves/death-claw.json
@@ -23,7 +23,8 @@
         "traits": [
           "contact",
           "drain-1-2",
-          "digimon"
+          "digimon",
+          "flinch-15"
         ],
         "cost": {
           "activation": "complex",
@@ -34,12 +35,13 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack inflicts 100 fixed damage to the target. The amount of health recovered on a successful hit is thus always 50.</p>",
+        "description": "<p>Effect: This Attack deals additional damage equal to half of the user's level.</p>",
         "range": {
           "target": "creature",
           "distance": 1,
           "unit": "m"
         },
+        "power": 85,
         "accuracy": 100
       }
     ],
@@ -47,6 +49,60 @@
     "slug": "death-claw"
   },
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Death Claw",
+      "type": "passive",
+      "_id": "S4j20jKRmSh4HwJS",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "death-claw-attack-damage-flat",
+            "value": "floor(@actor.system.advancement.level * 0.5)",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771277997499,
+        "modifiedTime": 1771278017754,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "hNyf1CTQOwW8PDEs"
 }

--- a/packs/moves/demi-dart.json
+++ b/packs/moves/demi-dart.json
@@ -23,25 +23,25 @@
         "traits": [
           "missile",
           "drain-1-4",
-          "digimon"
+          "digimon",
+          "3-strike"
         ],
         "range": {
-          "target": "enemy",
-          "distance": 10,
+          "target": "creature",
+          "distance": 5,
           "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 2
+          "activation": "complex",
+          "powerPoints": 3
         },
         "types": [
           "poison"
         ],
         "category": "physical",
-        "power": 60,
-        "accuracy": 100,
-        "predicate": [],
-        "description": "<p>Fires a poisonous, life-draining dart at the opponent.</p>"
+        "power": 40,
+        "accuracy": 90,
+        "predicate": []
       }
     ],
     "grade": "D",

--- a/packs/moves/demonic-disaster.json
+++ b/packs/moves/demonic-disaster.json
@@ -21,7 +21,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/dark_icon.svg",
         "traits": [
-          "reach",
+          "crushing",
           "dash",
           "crit-1",
           "contact",
@@ -38,7 +38,7 @@
         "predicate": [],
         "range": {
           "target": "creature",
-          "distance": 1,
+          "distance": 2,
           "unit": "m"
         },
         "power": 140,

--- a/packs/moves/desolation-claw.json
+++ b/packs/moves/desolation-claw.json
@@ -21,7 +21,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/dragon_icon.svg",
         "traits": [
-          "contact",
+          "flinch-20",
           "digimon"
         ],
         "cost": {
@@ -33,10 +33,10 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack has a 10% chance to apply @Affliction[perish 3].</p>",
+        "description": "<p>Effect: This Attack deals +50% more damage to @Trait[data] creatures.</p",
         "range": {
-          "target": "enemy",
-          "distance": 1,
+          "target": "creature",
+          "distance": 6,
           "unit": "m"
         },
         "power": 115,
@@ -56,23 +56,15 @@
       "system": {
         "changes": [
           {
-            "type": "roll-effect",
-            "key": "desolation-claw-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.perishcondititem",
-            "predicate": [],
-            "chance": 10,
-            "affects": "target",
-            "alterations": [
-              {
-                "mode": 5,
-                "property": "duration.turns",
-                "value": 3
-              }
+            "type": "flat-modifier",
+            "key": "desolation-claw-damage-flat",
+            "value": 50,
+            "predicate": [
+              "target:trait:data"
             ],
-            "dontMerge": false,
             "mode": 2,
             "ignored": false,
-            "isFixedChance": false
+            "hideIfDisabled": false
           }
         ],
         "slug": null,

--- a/packs/moves/desperado-blaster.json
+++ b/packs/moves/desperado-blaster.json
@@ -21,26 +21,27 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/dragon_icon.svg",
         "traits": [
-          "double-strike",
+          "4-strike",
           "missile",
-          "digimon"
+          "digimon",
+          "flinch-25"
         ],
         "cost": {
           "activation": "complex",
           "powerPoints": 6
         },
         "types": [
-          "dragon"
+          "untyped"
         ],
         "category": "physical",
         "predicate": [],
         "range": {
-          "target": "cone",
-          "distance": 4,
+          "target": "wide-line",
+          "distance": 14,
           "unit": "m"
         },
-        "power": 60,
-        "accuracy": 100
+        "power": 40,
+        "accuracy": 85
       }
     ],
     "grade": "B",

--- a/packs/moves/destroyed-hook.json
+++ b/packs/moves/destroyed-hook.json
@@ -22,11 +22,13 @@
         "img": "systems/ptr2e/img/svg/electric_icon.svg",
         "traits": [
           "digimon",
-          "pierce"
+          "pierce",
+          "crit-2",
+          "flinch-30"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 7
         },
         "types": [
           "steel",
@@ -34,17 +36,17 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack is considered both @Trait[electric] and @Trait[steel] type. On hit, this attack inflicts @Affliction[blight 8].</p>",
+        "description": "<p>Effect: On hit, this attack inflicts @Affliction[blight 6].</p>",
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 4,
           "unit": "m"
         },
         "power": 150,
         "accuracy": 80
       }
     ],
-    "grade": "E",
+    "grade": "A",
     "slug": "destroyed-hook"
   },
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
@@ -64,7 +66,13 @@
             "chance": 100,
             "isFixedChance": false,
             "affects": "target",
-            "alterations": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 6
+              }
+            ],
             "dontMerge": false,
             "mode": 2,
             "ignored": false

--- a/packs/moves/destroyed-rush.json
+++ b/packs/moves/destroyed-rush.json
@@ -24,10 +24,11 @@
           "digimon",
           "contact",
           "horn",
-          "pierce",
+          "hammer",
+          "sharp",
           "dash",
-          "5-strike",
-          "crit-2"
+          "8-strike",
+          "crit-1"
         ],
         "cost": {
           "activation": "complex",
@@ -40,11 +41,11 @@
         "predicate": [],
         "range": {
           "target": "creature",
-          "distance": 1,
+          "distance": 2,
           "unit": "m"
         },
-        "power": 25,
-        "accuracy": 100
+        "power": 30,
+        "accuracy": 90
       }
     ],
     "grade": "S"

--- a/packs/moves/dimension-scissor.json
+++ b/packs/moves/dimension-scissor.json
@@ -25,7 +25,9 @@
           "contact",
           "digimon",
           "pierce",
-          "crit-2"
+          "crit-2",
+          "jaw",
+          "flinch-30"
         ],
         "cost": {
           "activation": "complex",

--- a/packs/moves/divine-pierce.json
+++ b/packs/moves/divine-pierce.json
@@ -23,7 +23,7 @@
         "traits": [
           "contact",
           "weapon",
-          "pierce",
+          "crit-1",
           "digimon"
         ],
         "range": {
@@ -42,40 +42,105 @@
         "power": 65,
         "accuracy": 100,
         "predicate": []
-      },
-      {
-        "name": "Divine Pierce (Awake)",
-        "slug": "divine-pierce-awake",
-        "type": "attack",
-        "img": "systems/ptr2e/img/svg/fairy_icon.svg",
-        "traits": [
-          "contact",
-          "weapon",
-          "pierce"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 2,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2
-        },
-        "variant": "divine-pierce",
-        "types": [
-          "fairy"
-        ],
-        "category": "special",
-        "power": 65,
-        "accuracy": 100,
-        "predicate": []
       }
     ],
     "grade": "D",
     "slug": "divine-pierce"
   },
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Divine Pierce",
+      "type": "passive",
+      "_id": "6c7L7RJX15nsJwkz",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "key": "divine-pierce-attack",
+            "value": 45,
+            "predicate": [
+              "forme:awake:active"
+            ],
+            "property": "power",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "key": "divine-pierce-attack",
+            "value": "priority-20",
+            "predicate": [
+              "forme:awake:active"
+            ],
+            "property": "traits",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "key": "divine-pierce-attack",
+            "value": "pierce",
+            "predicate": [
+              "forme:awake:active"
+            ],
+            "property": "traits",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "key": "divine-pierce-attack",
+            "value": 4,
+            "predicate": [
+              "forme:awake:active"
+            ],
+            "property": "pp-cost",
+            "definition": [],
+            "mode": 5,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771284861256,
+        "modifiedTime": 1771285063637,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "dBepc88qKzmj8m6c"
 }

--- a/packs/moves/dot-matrix.json
+++ b/packs/moves/dot-matrix.json
@@ -33,19 +33,75 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack deals 2x UserLevel Flat Damage to all targets within range.</p>",
+        "description": "<p>Effect: This Attack deals additional damage equal to the user's level.</p>",
         "range": {
           "target": "emanation",
-          "distance": 3,
+          "distance": 5,
           "unit": "m"
         },
-        "accuracy": 100
+        "power": 55,
+        "accuracy": 95
       }
     ],
     "grade": "A",
     "slug": "dot-matrix"
   },
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Dot Matrix",
+      "type": "passive",
+      "_id": "rV7Qu3Dreeiw89XW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "dot-matrix-damage-flat",
+            "value": "@actor.system.advancement.level",
+            "predicate": [],
+            "label": "Dot Matrix",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771276557915,
+        "modifiedTime": 1771276734641,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "yMy5n5qCmUydlKiS"
 }

--- a/packs/moves/double-impact.json
+++ b/packs/moves/double-impact.json
@@ -22,25 +22,27 @@
         "img": "systems/ptr2e/img/svg/dark_icon.svg",
         "traits": [
           "digimon",
-          "10-strike",
-          "missile"
+          "8-strike",
+          "missile",
+          "firearm",
+          "crit-1"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 9
+          "powerPoints": 7
         },
         "types": [
           "dark"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>On hit, the target is inflicted with @Affliction[stunted 5] and @Affliction[bleed 5]. On resolution, even if the attack missed, the target gains @Affliction[fear 5].</p>",
+        "description": "<p>Effect: On hit, the target has a 40% chance of gaining @Affliction[stunted 7] and @Affliction[bleed 7].</p>",
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
-        "power": 20,
+        "power": 30,
         "accuracy": 90
       }
     ],
@@ -60,10 +62,16 @@
             "key": "double-impact-attack",
             "value": "Compendium.ptr2e.core-effects.Item.stuntedcondiitem",
             "predicate": [],
-            "chance": 100,
+            "chance": 40,
             "isFixedChance": false,
             "affects": "target",
-            "alterations": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
             "dontMerge": false,
             "mode": 2,
             "ignored": false
@@ -73,23 +81,16 @@
             "key": "double-impact-attack",
             "value": "Compendium.ptr2e.core-effects.Item.bleedconditiitem",
             "predicate": [],
-            "chance": 100,
+            "chance": 40,
             "isFixedChance": false,
             "affects": "target",
-            "alterations": [],
-            "dontMerge": false,
-            "mode": 2,
-            "ignored": false
-          },
-          {
-            "type": "roll-effect",
-            "key": "double-impact-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.fearconditioitem",
-            "predicate": [],
-            "chance": 100,
-            "isFixedChance": false,
-            "affects": "target",
-            "alterations": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
             "dontMerge": false,
             "mode": 2,
             "ignored": false

--- a/packs/moves/double-scissor-claw.json
+++ b/packs/moves/double-scissor-claw.json
@@ -25,11 +25,13 @@
           "pierce",
           "contact",
           "crit-1",
+          "jaw",
+          "sharp",
           "digimon"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 6
         },
         "types": [
           "bug"

--- a/packs/moves/dragon-impulse.json
+++ b/packs/moves/dragon-impulse.json
@@ -22,23 +22,27 @@
         "img": "systems/ptr2e/img/svg/dragon_icon.svg",
         "traits": [
           "recoil-1-2",
+          "dash",
+          "contact",
+          "flinch-30",
           "digimon"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 4
         },
         "types": [
-          "dragon"
+          "dragon",
+          "flying"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>This attack does 130 fixed flat damage to the target.</p>",
         "range": {
-          "target": "enemy",
-          "distance": 5,
+          "target": "creature",
+          "distance": 1,
           "unit": "m"
         },
+        "power": 170,
         "accuracy": 100
       }
     ],

--- a/packs/moves/dragonic-impact.json
+++ b/packs/moves/dragonic-impact.json
@@ -23,7 +23,6 @@
         "traits": [
           "digimon",
           "contact",
-          "pass-15",
           "dash",
           "crushing"
         ],
@@ -36,14 +35,14 @@
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>Effect: On hit, any owned creatures are returned to their respective capture devices.</p>",
+        "description": "<p>Effect: On resolution, the user may freely relocate itself to open space(s) at the end of this Attack's template.</p>",
         "range": {
-          "target": "creature",
-          "distance": 1,
+          "target": "wide-line",
+          "distance": 15,
           "unit": "m"
         },
         "power": 135,
-        "accuracy": 100
+        "accuracy": 90
       }
     ],
     "grade": "S"

--- a/packs/moves/dragons-roar.json
+++ b/packs/moves/dragons-roar.json
@@ -22,9 +22,7 @@
         "img": "systems/ptr2e/img/svg/dragon_icon.svg",
         "traits": [
           "digimon",
-          "double-strike",
-          "sonic",
-          "drain-1-2",
+          "ray",
           "pierce"
         ],
         "cost": {
@@ -38,17 +36,82 @@
         "predicate": [],
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 7,
           "unit": "m"
         },
         "power": 60,
-        "accuracy": 100
+        "accuracy": 100,
+        "defensiveStat": "spd",
+        "description": "<p>Effect: This Attack deals additional flat damage equal to the target's BST / 9, and has +10 Power per positive Stage the target has.</p>"
       }
     ],
     "grade": "S"
   },
   "img": "systems/ptr2e/img/svg/dragon_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Dragon's Roar",
+      "type": "passive",
+      "_id": "ecb5OWh9hUnKHfFW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "dragons-roar-power-flat",
+            "value": "10 * (max(0,@target.system.attributes.atk.stage)+max(0,@target.system.attributes.def.stage)+max(0,@target.system.attributes.spa.stage)+max(0,@target.system.attributes.spd.stage)+max(0,@target.system.attributes.spd.stage)+max(0,@target.system.battleStats.accuracy.stage)+max(0,@target.system.battleStats.evasion.stage)+max(0,round(@target.system.battleStats.critRate.stage*1.5)))",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "dragons-roar-damage-flat",
+            "value": "floor((@target.system.attributes.atk.base/9)+(@target.system.attributes.def.base/9)+(@target.system.attributes.hp.base/9)+(@target.system.attributes.spa.base/9)+(@target.system.attributes.spd.base/9)+(@target.system.attributes.spe.base/9))",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771285535852,
+        "modifiedTime": 1771285699718,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "flags": {},
   "_id": "GAH3ybWa5ybkVFxc"
 }

--- a/packs/moves/dumdum-uppercut.json
+++ b/packs/moves/dumdum-uppercut.json
@@ -41,7 +41,7 @@
         "power": 90,
         "accuracy": 95,
         "predicate": [],
-        "description": "<p>Effect: On hit, the target has a 10% change of being @Affliction[delay 30].</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chanCe of being @Affliction[delay 30].</p>"
       }
     ],
     "grade": "C",

--- a/packs/moves/dumdum-uppercut.json
+++ b/packs/moves/dumdum-uppercut.json
@@ -34,13 +34,14 @@
           "powerPoints": 3
         },
         "types": [
-          "nuclear"
+          "nuclear",
+          "steel"
         ],
         "category": "physical",
         "power": 90,
-        "accuracy": 100,
+        "accuracy": 95,
         "predicate": [],
-        "description": "<p>This attack has a 10% chance to delay the target's activation by 30%</p>"
+        "description": "<p>Effect: On hit, the target has a 10% change of being @Affliction[delay 30].</p>"
       }
     ],
     "grade": "C",
@@ -58,7 +59,7 @@
           {
             "type": "roll-effect",
             "key": "dumdum-uppercut-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
             "predicate": [],
             "chance": 10,
             "affects": "target",
@@ -68,11 +69,6 @@
                 "mode": 5,
                 "property": "system.amount",
                 "value": -30
-              },
-              {
-                "mode": 5,
-                "property": "name",
-                "value": "Flinch 30%"
               }
             ],
             "mode": 2,

--- a/packs/moves/electric-shock-betamon.json
+++ b/packs/moves/electric-shock-betamon.json
@@ -25,7 +25,7 @@
         ],
         "range": {
           "target": "creature",
-          "distance": 15,
+          "distance": 12,
           "unit": "m"
         },
         "cost": {
@@ -39,7 +39,7 @@
         "power": 55,
         "accuracy": 100,
         "predicate": [],
-        "description": "<p>This attack has a 10% chance to inflict @Affliction[paralysis] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[paralysis 5].</p>"
       }
     ],
     "grade": "D",
@@ -56,10 +56,10 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "electric-shock-betamon",
+            "key": "electric-shock-betamon-attack",
             "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
             "predicate": [],
-            "chance": 10,
+            "chance": 20,
             "affects": "target",
             "dontMerge": false,
             "mode": 2,

--- a/packs/moves/electro-shocker.json
+++ b/packs/moves/electro-shocker.json
@@ -26,12 +26,12 @@
         ],
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 5
         },
         "types": [
           "electric"
@@ -40,7 +40,7 @@
         "power": 80,
         "accuracy": 100,
         "predicate": [],
-        "description": "<p>This attack has a 20% chance to inflict @Affliction[tased 5]</p>"
+        "description": "<p>On hit, the target has a 20% chance to be @Affliction[tased 5], and if they are a @Trait[virus] creature they have a 20% chance to gain @Affliction[disabled 5] (selected randomly).</p>"
       }
     ],
     "grade": "C",
@@ -68,6 +68,22 @@
             "ignored": false,
             "alterations": [],
             "isFixedChance": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "electro-shocker-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.disabledconditem",
+            "predicate": [
+              "target:trait:virus"
+            ],
+            "chance": 20,
+            "affects": "target",
+            "dontMerge": false,
+            "priority": null,
+            "alterations": [],
+            "isFixedChance": false,
+            "mode": 2,
+            "ignored": false
           }
         ],
         "slug": null,

--- a/packs/moves/end-waltz.json
+++ b/packs/moves/end-waltz.json
@@ -21,33 +21,89 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/steel_icon.svg",
         "traits": [
-          "sonic",
-          "pulse",
           "digimon",
-          "5-strike"
+          "sky",
+          "wind"
         ],
         "cost": {
           "activation": "complex",
           "powerPoints": 9
         },
         "types": [
+          "flying",
           "steel"
         ],
         "category": "physical",
         "predicate": [],
         "range": {
-          "target": "cone",
-          "distance": 5,
+          "target": "emanation",
+          "distance": 2,
           "unit": "m"
         },
-        "power": 35,
-        "accuracy": 100
+        "power": 195,
+        "accuracy": 100,
+        "description": "<p>Effect: This attack is more powerful the slower the user is compared to the target ranging from 55 to 195.</p>"
       }
     ],
     "grade": "S",
     "slug": "end-waltz"
   },
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "End Waltz",
+      "type": "passive",
+      "_id": "WIfnTCM7u1ocLyc7",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "waltz-end-attack-power-flat",
+            "value": "-round(min(140,max(0,42*((@actor.system.attributes.spe.final*3.5-@target.system.attributes.spe.final)/@actor.system.attributes.spe.final))))",
+            "predicate": [],
+            "label": "End Waltz Scaling",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771286513507,
+        "modifiedTime": 1771288878356,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "aBC1dpW32mQveiyQ"
 }

--- a/packs/moves/eternal-nightmare.json
+++ b/packs/moves/eternal-nightmare.json
@@ -23,7 +23,8 @@
         "traits": [
           "digimon",
           "sonic",
-          "pierce"
+          "pierce",
+          "flinch-20"
         ],
         "cost": {
           "activation": "complex",
@@ -34,19 +35,117 @@
         ],
         "category": "special",
         "predicate": [],
-        "description": "<p>The damage value for this attack is equal to UserLevel x 1.75<br><br>This attack inflicts @Affliction[drowsy 7] on all valid targets. If the target already has @Affliction[drowsy], instead apply @Affliction[nightmares] with the appropriate duration.</p>",
+        "description": "<p>Effect: On hit, all valid targets gain @Affliction[drowsy 7]. Valid targets that already have @Affliction[drowsy] instead gain @Affliction[nightmares 7].</p>",
         "range": {
           "target": "emanation",
           "distance": 6,
           "unit": "m"
         },
-        "accuracy": 100
+        "accuracy": 95,
+        "power": 65
       }
     ],
     "grade": "S"
   },
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Eternal Nightmare",
+      "type": "passive",
+      "_id": "r84wy5htipkWbrXF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "eternal-nightmare-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [
+              {
+                "nor": [
+                  "effect:affliction:drowsy",
+                  "effect:affliction:nightmares"
+                ]
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "eternal-nightmare-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.nightmarescoitem",
+            "predicate": [
+              {
+                "or": [
+                  "effect:affliction:drowsy",
+                  "effect:affliction:nightmares"
+                ]
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771286753700,
+        "modifiedTime": 1771287034851,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "flags": {},
   "_id": "SK8wrizob1mlXXrh"
 }

--- a/packs/moves/exhaust-flame.json
+++ b/packs/moves/exhaust-flame.json
@@ -21,26 +21,26 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/fire_icon.svg",
         "traits": [
-          "sonic",
+          "pulse",
           "digimon"
         ],
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 5
         },
         "types": [
           "fire"
         ],
         "category": "physical",
-        "power": 85,
+        "power": 100,
         "accuracy": 100,
         "predicate": [],
-        "description": "<p>This attack has a 10% chance each to inflict @Affliction[poison 5] to the target, and +1 Attack Stage for 5 Activations to the user.</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[poison 5], and on resolution, the user has a 20% chance to gain +1 ATK Stage for 5 Activations.</p>"
       }
     ],
     "grade": "C",
@@ -74,7 +74,7 @@
             "key": "exhaust-flame-attack",
             "value": "Compendium.ptr2e.core-effects.Item.ZGwaMlzUwkSuCPyH",
             "predicate": [],
-            "chance": 10,
+            "chance": 20,
             "affects": "self",
             "dontMerge": false,
             "mode": 2,

--- a/packs/moves/extinction-wave.json
+++ b/packs/moves/extinction-wave.json
@@ -22,11 +22,11 @@
         "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "traits": [
           "digimon",
-          "danger-close"
+          "priority-20"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 8
         },
         "types": [
           "psychic"
@@ -34,18 +34,76 @@
         "category": "special",
         "predicate": [],
         "range": {
-          "target": "cone",
-          "distance": 5,
+          "target": "wide-line",
+          "distance": 10,
           "unit": "m"
         },
         "power": 105,
-        "accuracy": 100
+        "accuracy": 100,
+        "description": "<p>Effect: This Attack is two steps more effective against the @Trait[steel] Type.</p>"
       }
     ],
     "grade": "S"
   },
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Extinction Wave",
+      "type": "passive",
+      "_id": "ECNiqVYeloqoRlyS",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "extinction-wave-attack-effectiveness-stage",
+            "value": 2,
+            "predicate": [
+              "target:trait:steel"
+            ],
+            "label": "Vs Steel",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771287242241,
+        "modifiedTime": 1771287263636,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "flags": {},
   "_id": "kqnWU6z25ueILOot"
 }

--- a/packs/moves/summon.json
+++ b/packs/moves/summon.json
@@ -21,7 +21,9 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/dark_icon.svg",
         "traits": [
-          "digimon"
+          "digimon",
+          "arcane",
+          "flinch-20"
         ],
         "range": {
           "target": "creature",
@@ -33,12 +35,14 @@
           "powerPoints": 4
         },
         "types": [
-          "dark"
+          "fire",
+          "ice"
         ],
         "category": "special",
+        "power": 80,
         "accuracy": 100,
         "predicate": [],
-        "description": "<p>Effect: This attack deals flat damage based on the user's level. It also has a 30% chance to grant the user +1 Special Defense Stage for 3 activations.<br><br>Damage Formula: Damage = 1.5 x UserLevel.</p>"
+        "description": "<p>Effect: On hit, the target has a 15% chance of gaining @Affliction[burn 5] and @Affliction[frostbite 5].</p>"
       }
     ],
     "grade": "C",
@@ -56,9 +60,29 @@
           {
             "type": "roll-effect",
             "key": "summon-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
             "predicate": [],
-            "chance": 30,
+            "chance": 15,
+            "affects": "self",
+            "dontMerge": false,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "isFixedChance": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "summon-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frostbiteconitem",
+            "predicate": [],
+            "chance": 15,
             "affects": "self",
             "dontMerge": false,
             "alterations": [

--- a/packs/moves/taizoukai-mandala.json
+++ b/packs/moves/taizoukai-mandala.json
@@ -21,8 +21,9 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "traits": [
-          "danger-close",
-          "digimon"
+          "digimon",
+          "flinch-50",
+          "arcane"
         ],
         "cost": {
           "activation": "complex",
@@ -34,19 +35,77 @@
         ],
         "category": "special",
         "predicate": [],
-        "description": "<p>This attack counts as both @Trait[psychic] and @Trait[dark] type. Removes all positive Accuracy, Evasion and Critical @Trait[stage-change] effects from targets.</p>",
+        "description": "<p>Effect: This attack removes all negative @Trait[stage-change] effects from the user and all allies in range. This attack is both @Trait[dark] and @Trait[psychic], and is two steps more effective against the @Trait[fairy] Type.</p>",
         "range": {
           "target": "emanation",
-          "distance": 5,
+          "distance": 6,
           "unit": "m"
         },
-        "power": 90
+        "power": 100,
+        "accuracy": 95
       }
     ],
     "grade": "S",
     "slug": "taizoukai-mandala"
   },
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Amethyst Mandala",
+      "type": "passive",
+      "_id": "uNHW4Km2s1qImAn2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "amethyst-mandala-attack-effectiveness-stage",
+            "value": 2,
+            "predicate": [
+              "target:trait:fairy"
+            ],
+            "label": "Vs Fairy",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1771261243539,
+        "modifiedTime": 1771261273207,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "_id": "uNHW4Km2s1qIgUy1"
 }

--- a/packs/moves/terra-force.json
+++ b/packs/moves/terra-force.json
@@ -23,18 +23,20 @@
         "traits": [
           "digimon",
           "explode",
-          "blast-4"
+          "blast-4",
+          "pulse"
         ],
         "cost": {
           "activation": "complex",
           "powerPoints": 11
         },
         "types": [
+          "fighting",
           "fire"
         ],
         "category": "physical",
         "predicate": [],
-        "description": "<p>On resolution, the user has a 30% chance to gain @UUID[Compendium.ptr2e.core-effects.g1Gt9mJWimAqrqZ0]{+2 Attack Stages for 5 activations}.</p>",
+        "description": "<p>On resolution, the user has a 30% chance to gain +1 ATK Stage for 5 Activations.</p>",
         "range": {
           "target": "creature",
           "distance": 10,
@@ -59,7 +61,7 @@
           {
             "type": "roll-effect",
             "key": "terra-force-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.g1Gt9mJWimAqrqZ0",
+            "value": "Compendium.ptr2e.core-effects.Item.ZGwaMlzUwkSuCPyH",
             "predicate": [],
             "chance": 30,
             "isFixedChance": false,


### PR DESCRIPTION
**_Generally speaking_**: “Renamed” Moves were recommitted here (name changes undone), and Moves here updated to reflect additions/changes made in Time Stranger, or general thematic appropriateness.

More specific changes:

- Amethyst Mandala and Taizoukai Mandala brought into effect (dealing with stages and effectiveness increases) and damage parity.
- Arctic Blizzard adjusted to suit the new dynamic with Viking Axe.
- Atomic Ray updated to include valid Affliction, and revised to reduce effect chances slightly
- Baby Breath power and range reduced (to account for it being a Rookie signature), traits updated
- Banana Slip updated (Freeze doesn’t make sense, effect updated to more accurate reflect a “tripping” effect). Range reduced to a sensible amount, Power and Accuracy adjusted and Priority added to reflect the attack being more of an ailment action, PP also reduced following the aforementioned changes.
- Bifrost updated to be more of a RK move (added prio, added fire type, included Burn effect chance and updated SPD Stage effect, “Legendary” PP reduction applied).
- Big Bang Voice updated to be a wide line, rather than emanation. PP increased, Acc slightly reduced to account for Pierce AOE, slight increase to Paralysis chance.
- Biting Crush updated to be more of a 7DD move (added traits, removal of Perish, more emphasis on the biting+lockjaw dynamic re: grapples, power increased, acc adjusted per the aforementioned dynamic, “Legendary” PP reduction applied).
- Black Aura Blast updated to be more of a RK move (added prio, traits updated added dark type, included Confused effect chance and gyro ball type of effect since Leopardmon is slow and to reflect TS effect, “Legendary” PP reduction applied)
- Black Rain overhauled into a proper Set Up move - targeting the field with chances to inflict Confused and Wracked, and deal damage targeting foes’ Speed.
- Blade of the Dragon King updated with an actual effect, revised to be Steel Type, “Legendary” PP reduction applied.
- Blaze Sonic Breath traits updated, range, accuracy, and effect revised to account for Line targeting. PP reduced slightly.
- Blue Flare Breath effect chance altered, given fae-bonus effect from TS.
- Brave Metal brought in line with all other Set Up Moves, text revisions, given TS effectiveness increases.
- Bunny Blades Power increase, Accuracy decrease, trait updates (axes = hammers), slight PP reduction.
- Burst Shot revised to 3-strike (power adjusted as necessary, to be similar to Bunny Blades), cone size increased, Accuracy reduced (for cone).
- Catastrophe Cannon reworked away from simple action and the awkward Bound condition. Given an effect similar to Water Spout, Flinch increased. Range, Power, Accuracy revised as appropriate for the attack (being more of an artillery type move).
- Chrono Breaker flat damage effect revised to scale off user level, traits updated, added effect chances for Delay and Drowsy (similar to TS).
- Cold Flame adjusted to be better against Ice and Fire Types, trait addition.
- Corona Blaster made 6-strike, power increased, with accuracy slightly reduced for balance.
- Cross Blade added Steel Type (to fit Grademon), increased Crit, removal of danger close.
- Darkness Zone wording fixes, added Flinch and PP increase for balance.
- Dark Roar increased crit, adding chance grounded effect (to reflect lore of the shots being made of superheavy dark matter)
- Data Crusher effect changed from Perish 1 (??!!) to instead be a chance to reduce all of the foe’s Stages by -1. 
- Dead or Alive updated to be more of a 7DD move (chance of inflicting Wracked, inflicts 3.5xlevel flat damage and Perish 3 on Crit, given Crit 1, Power adjusted, “Legendary” PP reduction applied).
- Death Claw effect tidied up, given Flinch 15, Power 85.
- Desperado Blaster adjusted similarly to Burst Shot - made Wide Line line, 4-strike, range increase, power/acc adjustment, plus some Flinch to keep PP cost lower. Made untyped (like the attack is in CSHM and TS).
- Demonic Disaster removing Reach, adding Crushing. Range increase.
- Desolation Claw made into an “energy wave” like they are in most media depictions. Added Data damage effect from TS, removal of Perish.
- Destroyed Hook adds Crit 2 and Flinch 30, Blight Stacks and Range reduced, PP cost reduced a decent amount.
- Destroyed Rush traits revised, pierce removed, crit reduced, increased to 8 strike, range increased by 1, power and accuracy adjusted to keep cost consistent.
- Dimension Scissor added Jaw, added Flinch 30 to account for a high-damage Pierce on a 100 accuracy Move.
- Divine Pierce revamped to have effects/modifications unique to the Sistermon’s Awake Forme.
- Dot Matrix Effect revised, given Power 55, range and PP increased, Accuracy reduced slightly
- Double Impact reduced to 8 Strike, given firearm and crit 1, swapped to Steel type (bcuz gun), remove “even on miss” effect, effect chances reduced and durations increased, slight PP and range reduction, Power increase.
- Double Scissor Claw added jaw and sharp, PP increased to account for access to double Pierce.
- Dragonic Impact reworked to be more like Surf than a traditional Pass Attack (more akin to the Attack’s animation in various media).
- Dragon Impulse reworked to be a more traditional high-damaging attack, rather than a flat damaging attack, given Flying type.
- Dragon’s Roar converted into a Ray (like its depictions elsewhere), loses Double Strike, given an effect that is a blend of Legendslayer and Punishment (to suit a Royal Knight).
- Dumdum Uppercut effect text revised, given Steel type, given slight accuracy reduction (to reflect the attack’s well-known awkwardness in various media)
- Electro Shocker given a chance to inflict Disabled on Virus creatures, PP increased slightly, range reduced by 2.
- End Waltz completely overhauled to reflect the Attack’s depiction in various media (and to fit a Royal Knight), functions like Gust+Gyro Ball.
- Eternal Nightmare effect revised, given automation for applying Nightmare on Drowsy targets. Given 65 Power, 95 Accuracy, and Flinch 20.
- Exhaust Flame traits revised, attack stage chance increased, Power increased, PP increased, range decreased slightly
- Extinction Wave updated to be more of a RK move (added prio, change to a longer ranged Wide Line, updated to be SE against Steel to reflect TS effect, “Legendary” PP reduction applied).
- Summon adapted to resemble the attack’s fire+ice animation, removing flat damage, given Arcane, Flinch 20, Fire/Ice Typing, Power 80 (since it isn’t naturally STAB).
- Terra Force brought in line with Dark Terra Force.