### PR TITLE
Foundry Data Sync - BaoHuckmon Ability Switch

### DIFF
--- a/packs/species/bao-huckmon.json
+++ b/packs/species/bao-huckmon.json
@@ -49,7 +49,7 @@
           "slug": "stubborn"
         },
         {
-          "slug": "martial-training"
+          "slug": "raw-firepower"
         }
       ],
       "basic": [
@@ -888,11 +888,12 @@
               "granter": "cascade"
             },
             "reevaluateOnUpdate": true,
-            "mode": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false
+            "replaceSelf": false,
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -905,8 +906,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -923,13 +926,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.12.beta",
         "createdTime": 1767051375162,
         "modifiedTime": 1767051666395,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "I7rfa9ufBf6rewVr"


### PR DESCRIPTION
Previously had Fighting STAB ability. Seeing as someone previously made it fighting type, replaced this with Fire type STAB.
- Update Digimonspecies: BaoHuckmon