### PR TITLE
Foundry Data Sync - Digimon Moves Double Strike Cost Fix

### DIFF
--- a/packs/moves/desperado-blaster.json
+++ b/packs/moves/desperado-blaster.json
@@ -19,7 +19,7 @@
         "name": "Desperado Blaster",
         "slug": "desperado-blaster",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5327.png",
         "traits": [
           "double-strike",
           "missile",
@@ -27,7 +27,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 3
         },
         "types": [
           "dragon"
@@ -40,13 +40,14 @@
           "unit": "m"
         },
         "power": 60,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "B",
+    "grade": "A",
     "slug": "desperado-blaster"
   },
-  "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5327.png",
   "effects": [],
   "_id": "4D9vXLCSUXstld3k"
 }

--- a/packs/moves/double-scissor-claw.json
+++ b/packs/moves/double-scissor-claw.json
@@ -19,7 +19,7 @@
         "name": "Double Scissor Claw",
         "slug": "double-scissor-claw",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/bug_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5291.png",
         "traits": [
           "double-strike",
           "pierce",
@@ -29,7 +29,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 3
         },
         "types": [
           "bug"
@@ -42,13 +42,14 @@
           "unit": "m"
         },
         "power": 60,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
     "grade": "A",
     "slug": "double-scissor-claw"
   },
-  "img": "systems/ptr2e/img/svg/bug_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5291.png",
   "effects": [],
   "_id": "KCRf8bWrk54HeGNu"
 }

--- a/packs/moves/double-stars.json
+++ b/packs/moves/double-stars.json
@@ -19,7 +19,7 @@
         "name": "Double Stars",
         "slug": "double-stars",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/steel_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5201.png",
         "traits": [
           "digimon",
           "double-strike",
@@ -27,7 +27,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 2
         },
         "types": [
           "steel"
@@ -41,12 +41,14 @@
           "unit": "m"
         },
         "power": 30,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "C"
+    "grade": "C",
+    "slug": "double-stars"
   },
-  "img": "systems/ptr2e/img/svg/steel_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5201.png",
   "effects": [
     {
       "name": "Double Stars",
@@ -62,9 +64,10 @@
             "predicate": [
               "target:trait:dragon"
             ],
-            "mode": 2,
             "ignored": false,
-            "hideIfDisabled": true
+            "hideIfDisabled": true,
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -77,8 +80,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -95,13 +100,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "D5yVOCKCOKQpBtyr"
 }

--- a/packs/moves/dragons-roar.json
+++ b/packs/moves/dragons-roar.json
@@ -19,7 +19,7 @@
         "name": "Dragon's Roar",
         "slug": "dragons-roar",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5380.png",
         "traits": [
           "digimon",
           "double-strike",
@@ -29,7 +29,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 4
         },
         "types": [
           "dragon"
@@ -42,13 +42,14 @@
           "unit": "m"
         },
         "power": 60,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "S"
+    "grade": "S",
+    "slug": "dragons-roar"
   },
-  "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5380.png",
   "effects": [],
-  "flags": {},
   "_id": "GAH3ybWa5ybkVFxc"
 }

--- a/packs/moves/dual-swallow-reversal.json
+++ b/packs/moves/dual-swallow-reversal.json
@@ -19,7 +19,7 @@
         "name": "Dual Swallow Reversal",
         "slug": "dual-swallow-reversal",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/steel_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5124.png",
         "traits": [
           "digimon",
           "contact",
@@ -29,7 +29,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 2
         },
         "types": [
           "steel"
@@ -42,13 +42,14 @@
           "unit": "m"
         },
         "power": 30,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "C"
+    "grade": "C",
+    "slug": "dual-swallow-reversal"
   },
-  "img": "systems/ptr2e/img/svg/steel_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5124.png",
   "effects": [],
-  "flags": {},
   "_id": "Rncz2p2MK480T813"
 }

--- a/packs/moves/endless-surge.json
+++ b/packs/moves/endless-surge.json
@@ -19,7 +19,7 @@
         "name": "Endless Surge",
         "slug": "endless-surge",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/fire_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5365.png",
         "traits": [
           "digimon",
           "ray",
@@ -27,7 +27,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 7
+          "powerPoints": 3
         },
         "types": [
           "fire"
@@ -41,12 +41,14 @@
           "unit": "m"
         },
         "power": 45,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "A"
+    "grade": "A",
+    "slug": "endless-surge"
   },
-  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5365.png",
   "effects": [
     {
       "name": "Endless Surge",
@@ -62,9 +64,10 @@
             "predicate": [
               "target:trait:data"
             ],
-            "mode": 2,
             "ignored": false,
-            "hideIfDisabled": false
+            "hideIfDisabled": false,
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -77,8 +80,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -95,13 +100,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "DIyNH94F6RXVTwMQ"
 }

--- a/packs/moves/fif-cross.json
+++ b/packs/moves/fif-cross.json
@@ -19,7 +19,7 @@
         "name": "Fif Cross",
         "slug": "fif-cross",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/fighting_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5155.png",
         "traits": [
           "double-strike",
           "contact",
@@ -27,7 +27,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 2
         },
         "types": [
           "fighting"
@@ -40,13 +40,14 @@
           "unit": "m"
         },
         "power": 55,
-        "accuracy": 90
+        "accuracy": 90,
+        "free": true
       }
     ],
     "grade": "C",
     "slug": "fif-cross"
   },
-  "img": "systems/ptr2e/img/svg/fighting_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5155.png",
   "effects": [],
   "_id": "4zLUFypQZ8lZT2CC"
 }

--- a/packs/moves/genocidal-gears.json
+++ b/packs/moves/genocidal-gears.json
@@ -19,7 +19,7 @@
         "name": "Genocidal Gears",
         "slug": "genocidal-gears",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/steel_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5294.png",
         "traits": [
           "missile",
           "double-strike",
@@ -28,7 +28,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 7
+          "powerPoints": 4
         },
         "types": [
           "steel"
@@ -41,13 +41,14 @@
           "unit": "m"
         },
         "power": 60,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
     "grade": "A",
     "slug": "genocidal-gears"
   },
-  "img": "systems/ptr2e/img/svg/steel_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5294.png",
   "effects": [],
   "_id": "iNcGh7izDXjQtlzz"
 }

--- a/packs/moves/howling-crusher.json
+++ b/packs/moves/howling-crusher.json
@@ -19,7 +19,7 @@
         "name": "Howling Crusher",
         "slug": "howling-crusher",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/rock_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5376.png",
         "traits": [
           "contact",
           "jaw",
@@ -29,7 +29,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 4
         },
         "types": [
           "rock"
@@ -42,13 +42,14 @@
           "unit": "m"
         },
         "power": 65,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
     "grade": "S",
     "slug": "howling-crusher"
   },
-  "img": "systems/ptr2e/img/svg/rock_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5376.png",
   "effects": [],
   "_id": "MgdQqag8DasYo9FQ"
 }

--- a/packs/moves/ice-wolf-claw.json
+++ b/packs/moves/ice-wolf-claw.json
@@ -19,7 +19,7 @@
         "name": "Ice Wolf Claw",
         "slug": "ice-wolf-claw",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/ice_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5388.png",
         "traits": [
           "digimon",
           "missile",
@@ -27,7 +27,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 12
+          "powerPoints": 6
         },
         "types": [
           "ice"
@@ -41,12 +41,14 @@
           "unit": "m"
         },
         "power": 60,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "S"
+    "grade": "S",
+    "slug": "ice-wolf-claw"
   },
-  "img": "systems/ptr2e/img/svg/ice_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5388.png",
   "effects": [
     {
       "name": "Ice Wolf Claw",
@@ -58,14 +60,15 @@
           {
             "type": "roll-effect",
             "key": "ice-wolf-claw-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.frozencondititem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.frozencondition0",
             "predicate": [],
             "chance": 10,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "mode": 2,
+            "phase": "initial",
+            "method": 2,
             "ignored": false
           }
         ],
@@ -79,8 +82,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -97,13 +102,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.4.beta",
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "createdTime": 1777546084094,
+        "modifiedTime": 1777546084094
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "fvfC6M9xtEpdJixU"
 }

--- a/packs/moves/mega-burst.json
+++ b/packs/moves/mega-burst.json
@@ -19,7 +19,7 @@
         "name": "Mega Burst",
         "slug": "mega-burst",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/fire_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5114.png",
         "traits": [
           "double-strike",
           "missile",
@@ -27,7 +27,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 2
         },
         "types": [
           "fire"
@@ -40,13 +40,14 @@
           "unit": "m"
         },
         "power": 45,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
     "grade": "C",
     "slug": "mega-burst"
   },
-  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5114.png",
   "effects": [],
   "_id": "kASbI1uL1f245XHM"
 }

--- a/packs/moves/mystic-flame.json
+++ b/packs/moves/mystic-flame.json
@@ -19,7 +19,7 @@
         "name": "Mystic Flame",
         "slug": "mystic-flame",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5406.png",
         "traits": [
           "digimon",
           "arcane",
@@ -29,7 +29,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 3
         },
         "types": [
           "normal"
@@ -43,12 +43,14 @@
           "unit": "m"
         },
         "power": 50,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "A"
+    "grade": "A",
+    "slug": "mystic-flame"
   },
-  "img": "systems/ptr2e/img/svg/normal_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5406.png",
   "effects": [
     {
       "name": "Mystic Flame",
@@ -64,9 +66,10 @@
             "predicate": [
               "target:trait:dark"
             ],
-            "mode": 2,
             "ignored": false,
-            "hideIfDisabled": false
+            "hideIfDisabled": false,
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -79,8 +82,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -97,13 +102,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "D6cPxO3Z8amafyOf"
 }

--- a/packs/moves/needle-squall.json
+++ b/packs/moves/needle-squall.json
@@ -19,14 +19,14 @@
         "name": "Needle Squall",
         "slug": "needle-squall",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/steel_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5419.png",
         "traits": [
           "digimon",
           "double-strike"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 3
         },
         "types": [
           "steel"
@@ -40,12 +40,14 @@
           "unit": "m"
         },
         "power": 40,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "A"
+    "grade": "A",
+    "slug": "needle-squall"
   },
-  "img": "systems/ptr2e/img/svg/steel_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5419.png",
   "effects": [
     {
       "name": "Needle Squall",
@@ -61,9 +63,10 @@
             "predicate": [
               "target:trait:water"
             ],
-            "mode": 2,
             "ignored": false,
-            "hideIfDisabled": false
+            "hideIfDisabled": false,
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -76,8 +79,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -94,13 +99,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "V1A9BTcPMJ1WezGc"
 }

--- a/packs/moves/prominence-laser.json
+++ b/packs/moves/prominence-laser.json
@@ -1,0 +1,54 @@
+{
+  "name": "Prominence Laser",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "prominence-laser",
+    "publication": {
+      "source": "Digidex",
+      "authors": [
+        "Krueger"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Prominence Laser",
+        "slug": "prominence-laser",
+        "type": "attack",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5524.png",
+        "traits": [
+          "pierce",
+          "ray",
+          "double-strike",
+          "digimon"
+        ],
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "fire"
+        ],
+        "category": "special",
+        "free": true,
+        "predicate": [],
+        "range": {
+          "target": "creature",
+          "distance": 15,
+          "unit": "m"
+        },
+        "power": 70,
+        "accuracy": 100
+      }
+    ],
+    "grade": "A"
+  },
+  "_id": "icH6toXB3Y6Y4FDI",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5524.png",
+  "effects": []
+}

--- a/packs/moves/purgatory-claws.json
+++ b/packs/moves/purgatory-claws.json
@@ -1,5 +1,4 @@
 {
-  "folder": null,
   "name": "Purgatory Claws",
   "type": "move",
   "system": {
@@ -21,7 +20,7 @@
         "name": "Purgatory Claws",
         "slug": "purgatory-claws",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/fire_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5504.png",
         "traits": [
           "digimon",
           "double-strike",
@@ -32,26 +31,13 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "trigger": "",
-          "delay": null,
-          "priority": null
+          "powerPoints": 4
         },
-        "variant": null,
-        "ephemeralVariant": false,
-        "summon": null,
         "types": [
           "fire",
           "dark"
         ],
         "category": "special",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "defaultVariant": null,
-        "flingItemId": "",
-        "offensiveStat": null,
         "defensiveStat": "def",
         "predicate": [],
         "description": "<p>Effect: Targets DEF. On hit, the target has a 30% chance to lose -1 DEF and SPDEF Stage for 7 Activations and a 10% chance to gain @Affliction[burn 7].</p>",
@@ -61,14 +47,13 @@
           "unit": "m"
         },
         "power": 50,
-        "accuracy": 95
+        "accuracy": 95,
+        "free": true
       }
     ],
-    "description": "",
-    "container": null,
     "grade": "A"
   },
-  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5504.png",
   "effects": [
     {
       "name": "Purgatory Claws",
@@ -80,58 +65,61 @@
           {
             "type": "roll-effect",
             "key": "purgatory-claws-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.bdYCJcqjMNqTpJJQ",
             "predicate": [],
             "chance": 20,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [
               {
-                "mode": 5,
+                "method": 5,
                 "property": "duration.turns",
                 "value": 7
               }
             ],
             "dontMerge": false,
-            "mode": 2,
+            "phase": "initial",
+            "method": 2,
             "ignored": false
           },
           {
             "type": "roll-effect",
             "key": "purgatory-claws-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.qe5aLBJuwb9eYqvv",
             "predicate": [],
             "chance": 20,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [
               {
-                "mode": 5,
+                "method": 5,
                 "property": "duration.turns",
                 "value": 7
               }
             ],
             "dontMerge": false,
-            "mode": 2,
+            "phase": "initial",
+            "method": 2,
             "ignored": false
           },
           {
             "type": "roll-effect",
             "key": "purgatory-claws-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.burncondition000",
             "predicate": [],
             "chance": 10,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [
               {
-                "mode": 5,
+                "method": 5,
                 "property": "duration.turns",
                 "value": 7
               }
             ],
             "dontMerge": false,
-            "mode": 2,
+            "phase": "initial",
+            "method": 2,
             "ignored": false
           }
         ],
@@ -145,8 +133,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -163,29 +153,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.5.0.beta",
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.4.beta",
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "createdTime": 1777549185784,
+        "modifiedTime": 1777549210220
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "ownership": {
-    "default": 0,
-    "Bk6N5iKyebvEVXhL": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "exportSource": null,
-    "coreVersion": "13.351",
-    "systemId": "ptr2e",
-    "systemVersion": "1.5.0.beta",
-    "createdTime": 1770078156155,
-    "modifiedTime": 1770078156155,
-    "lastModifiedBy": "Bk6N5iKyebvEVXhL"
-  },
-  "_id": "wyUUPnKnWQ9wGODx",
-  "sort": 0
+  "_id": "wyUUPnKnWQ9wGODx"
 }

--- a/packs/moves/pyro-punches.json
+++ b/packs/moves/pyro-punches.json
@@ -19,7 +19,7 @@
         "name": "Pyro Punches",
         "slug": "pyro-punches",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/fire_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5208.png",
         "traits": [
           "double-strike",
           "contact",
@@ -32,7 +32,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 2
         },
         "types": [
           "fire"
@@ -40,13 +40,14 @@
         "category": "physical",
         "power": 45,
         "accuracy": 100,
-        "predicate": []
+        "predicate": [],
+        "free": true
       }
     ],
     "grade": "C",
     "slug": "pyro-punches"
   },
-  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5208.png",
   "effects": [],
   "_id": "KktWQUMMLxAVW6xX"
 }

--- a/packs/moves/rolling-tackle.json
+++ b/packs/moves/rolling-tackle.json
@@ -1,0 +1,150 @@
+{
+  "folder": null,
+  "name": "Rolling Tackle",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "Digidex",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Rolling Tackle",
+        "slug": "rolling-tackle",
+        "type": "attack",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5132.png",
+        "traits": [
+          "digimon",
+          "sharp",
+          "curl",
+          "double-strike",
+          "contact",
+          "crit-1",
+          "dash"
+        ],
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2,
+          "trigger": "",
+          "delay": null,
+          "priority": null
+        },
+        "variant": null,
+        "ephemeralVariant": false,
+        "summon": null,
+        "types": [
+          "steel"
+        ],
+        "category": "physical",
+        "contestType": "",
+        "contestEffect": "",
+        "free": true,
+        "slot": null,
+        "defaultVariant": null,
+        "flingItemId": "",
+        "offensiveStat": null,
+        "defensiveStat": null,
+        "predicate": [],
+        "description": "<p>Effect: This attack deals +50% Damage vs @Trait[grass] creatures.</p>",
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "power": 40,
+        "accuracy": 100
+      }
+    ],
+    "description": "",
+    "container": null,
+    "grade": "B"
+  },
+  "_id": "jok3Exb9BhQsxGgx",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5132.png",
+  "effects": [
+    {
+      "name": "Rolling Tackle",
+      "type": "passive",
+      "_id": "DodYLOGtVXfHQTbY",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "value": 50,
+            "phase": "initial",
+            "predicate": [
+              "target:trait:grass"
+            ],
+            "label": "Vs Grass",
+            "key": "rolling-tackle-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1780665958718,
+        "modifiedTime": 1780665958718,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "ownership": {
+    "default": 0,
+    "VGuCUKsxs9UY3xDR": 3
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "ptr2e",
+    "systemVersion": "1.7.6.beta",
+    "createdTime": 1780665958718,
+    "modifiedTime": 1783071934196,
+    "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+    "exportSource": null,
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "sort": 4600000
+}

--- a/packs/moves/stinger-surprise.json
+++ b/packs/moves/stinger-surprise.json
@@ -19,14 +19,14 @@
         "name": "Stinger Surprise",
         "slug": "stinger-surprise",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/water_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5252.png",
         "traits": [
           "digimon",
           "double-strike"
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 3
         },
         "types": [
           "water"
@@ -40,13 +40,82 @@
           "unit": "m"
         },
         "power": 35,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
-    "grade": "B"
+    "grade": "B",
+    "slug": "stinger-surprise"
   },
-  "img": "systems/ptr2e/img/svg/water_icon.svg",
-  "effects": [],
-  "flags": {},
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5252.png",
+  "effects": [
+    {
+      "name": "Stinger Surprise",
+      "type": "passive",
+      "_id": "C4ip0em71LKSec7L",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.perishcondition0",
+            "phase": "initial",
+            "predicate": [
+              "target:effect:confused"
+            ],
+            "chance": 25,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 1
+              }
+            ],
+            "dontMerge": false,
+            "key": "stinger-surprise-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.4.beta",
+        "createdTime": 1777553411566,
+        "modifiedTime": 1777553423730,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
   "_id": "swpbQBBDggW1QISS"
 }

--- a/packs/moves/will-o-wisp-slash.json
+++ b/packs/moves/will-o-wisp-slash.json
@@ -19,7 +19,7 @@
         "name": "Will-O-Wisp Slash",
         "slug": "will-o-wisp-slash",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/fire_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5398.png",
         "traits": [
           "digimon",
           "contact",
@@ -28,7 +28,7 @@
         ],
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 4
         },
         "types": [
           "fire"
@@ -41,13 +41,14 @@
           "unit": "m"
         },
         "power": 70,
-        "accuracy": 100
+        "accuracy": 100,
+        "free": true
       }
     ],
     "grade": "S",
     "slug": "will-o-wisp-slash"
   },
-  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5398.png",
   "effects": [],
   "_id": "FkyZeoHGiVn327T7"
 }

--- a/packs/moves/zwei-sieger.json
+++ b/packs/moves/zwei-sieger.json
@@ -19,7 +19,7 @@
         "name": "Zwei Sieger",
         "slug": "zwei-sieger",
         "type": "attack",
-        "img": "systems/ptr2e/img/svg/fairy_icon.svg",
+        "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5209.png",
         "traits": [
           "sharp",
           "contact",
@@ -34,7 +34,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3
+          "powerPoints": 2
         },
         "types": [
           "fairy"
@@ -42,13 +42,14 @@
         "category": "physical",
         "power": 45,
         "accuracy": 100,
-        "predicate": []
+        "predicate": [],
+        "free": true
       }
     ],
     "grade": "C",
     "slug": "zwei-sieger"
   },
-  "img": "systems/ptr2e/img/svg/fairy_icon.svg",
+  "img": "modules/ptr2e-digimon-expansion/img/crystal-sprites/5209.png",
   "effects": [],
   "_id": "AgpigxDKR2qARlhk"
 }


### PR DESCRIPTION
Some of the older moves were made before 2-Strike became Double-Strike
- Update Move: Desperado Blaster
- Update Move: Double Scissor Claw
- Update Move: Double Stars
- Update Move: Dragon's Roar
- Update Move: Dual Swallow Reversal
- Update Move: Endless Surge
- Update Move: Fif Cross
- Update Move: Genocidal Gears
- Update Move: Howling Crusher
- Update Move: Ice Wolf Claw
- Update Move: Mega Burst
- Update Move: Mystic Flame
- Update Move: Needle Squall
- Update Move: Prominence Laser
- Update Move: Purgatory Claws
- Update Move: Pyro Punches
- Create Move: Rolling Tackle
- Update Move: Stinger Surprise
- Update Move: Will-O-Wisp Slash
- Update Move: Zwei Sieger